### PR TITLE
Task #257158 refactor: move fluency/prosody logic to service, fix rec…

### DIFF
--- a/src/common/enums/scores.enum.ts
+++ b/src/common/enums/scores.enum.ts
@@ -1,0 +1,30 @@
+export enum FluencyClassification {
+  FLUENT = 'Fluent',
+  MODERATELY_FLUENT = 'Moderately Fluent',
+  DISFLUENT = 'Disfluent',
+  VERY_DISFLUENT = 'Very Disfluent',
+}
+
+export enum ProsodyClassification {
+  NATURAL = 'natural',
+  FLAT = 'flat',
+  EXAGGERATED = 'exaggerated',
+  ERRATIC = 'erratic',
+}
+
+export enum SessionResult {
+  PASS = 'pass',
+  FAIL = 'fail',
+}
+
+export enum SupportedLanguage {
+  EN = 'en',
+  KN = 'kn',
+  TE = 'te',
+  HI = 'hi',
+  TA = 'ta',
+  OR = 'or',
+  GU = 'gu',
+}
+
+export const SUPPORTED_LANGUAGES: readonly string[] = Object.values(SupportedLanguage);

--- a/src/mongodb/config/language/common/commonConfig.ts
+++ b/src/mongodb/config/language/common/commonConfig.ts
@@ -11,7 +11,7 @@ var lang_common_config = {
     sub: 5,
   },
   fluencyAndProsody: {
-    passThresholdM4Plus: 3.0,
+    passThresholdM4Plus: 3,
     passThresholdBelowM4: 2.6,
     // Weighted contribution of each fluency feature to the overall score.
     weights: {

--- a/src/mongodb/config/language/common/commonConfig.ts
+++ b/src/mongodb/config/language/common/commonConfig.ts
@@ -10,6 +10,17 @@ var lang_common_config = {
     del: 15,
     sub: 5,
   },
+  fluencyAndProsody: {
+    passThresholdM4Plus: 3.0,
+    passThresholdBelowM4: 2.6,
+    // Weighted contribution of each fluency feature to the overall score.
+    weights: {
+      expression: 0.2,
+      smoothness: 0.1,
+      accuracy: 0.4,
+      rate: 0.3,
+    },
+  },
 };
 
 export default lang_common_config;

--- a/src/mongodb/scores.controller.ts
+++ b/src/mongodb/scores.controller.ts
@@ -51,6 +51,7 @@ import hi_config from './config/language/hi';
 import kn_config from './config/language/kn';
 import { isNotEmptyObject } from 'class-validator';
 import { splitGraphemes } from "split-graphemes";
+import { SessionResult } from 'src/common/enums/scores.enum';
 
 const Public = () => SetMetadata('isPublic', true);
 @ApiTags('scores')
@@ -6144,208 +6145,20 @@ export class ScoresController {
         sessionResult = 'fail';
       }
 
-      const langLowerShowcase = requestLanguage.toLowerCase();
-      const showcaseLangs = ['en', 'kn', 'te', 'hi', 'ta', 'or', 'gu'];
-      let cachedSubSessionScoresForShowcase: any[] | null = null;
-      const loadShowcaseSubSessionScores = async () => {
-        if (!cachedSubSessionScoresForShowcase) {
-          cachedSubSessionScoresForShowcase =
-            await this.scoresService.getSubSessionScores(
-              user_id,
-              subSessionId,
-              langLowerShowcase,
-            );
-        }
-        return cachedSubSessionScoresForShowcase;
-      };
-
-      // NEW: Compute fluencyResult.
-      let fluencyResult: string;
-      if (
-        !getSetResult.hasOwnProperty('collectionId') ||
-        !getSetResult.collectionId
-      ) {
-        const userLevelNum = parseInt(previous_level?.replace('m', ''), 10);
-        if (
-          showcaseLangs.includes(langLowerShowcase) &&
-          userLevelNum < 10
-        ) {
-          // Determine pass threshold based on milestone level.
-          // For M4+ (e.g. level >= 4) threshold is 3.0; otherwise, 2.6.
-
-          const passThreshold = userLevelNum >= 4 ? 3.0 : 2.6;
-
-          // Retrieve all audio records for the given sub-session and languages.
-
-          const allAudioRecords = await loadShowcaseSubSessionScores();
-
-          const totalAudios = allAudioRecords.length;
-          let passCount = 0;
-
-          // Loop through each audio record.
-          for (const record of allAudioRecords) {
-            const prosody = record.prosody_fluency || {};
-            const exprClass =
-              prosody.expression_classification || 'Very Disfluent';
-            const smoothClass =
-              (prosody.smoothness &&
-                prosody.smoothness.smoothness_classification) ||
-              'Very Disfluent';
-            const accClass =
-              (prosody.accuracy && prosody.accuracy.accuracy_classification) ||
-              'Very Disfluent';
-            const rateClass =
-              (prosody.rate && prosody.rate.rate_classification) ||
-              'Very Disfluent';
-
-            // Convert the classification strings to numeric scores.
-            const exprScore =
-              this.scoresService.classificationToScore(exprClass);
-            const smoothScore =
-              this.scoresService.classificationToScore(smoothClass);
-            const accScore = this.scoresService.classificationToScore(accClass);
-            const rateScore =
-              this.scoresService.classificationToScore(rateClass);
-
-            // Compute the weighted score.
-            const weightedScore =
-              exprScore * 0.2 +
-              smoothScore * 0.1 +
-              accScore * 0.4 +
-              rateScore * 0.3;
-
-            // Determine if this record passes.
-            let recordPass = false;
-            if (userLevelNum >= 4) {
-              if (weightedScore >= passThreshold) {
-                recordPass = true;
-              } else {
-                // Exception: for M4+, if weightedScore is below 3.0, then check for these combinations.
-                if (
-                  (exprClass === 'Moderately Fluent' &&
-                    smoothClass === 'Disfluent' &&
-                    accClass === 'Moderately Fluent' &&
-                    rateClass === 'Moderately Fluent') ||
-                  (exprClass === 'Disfluent' &&
-                    smoothClass === 'Fluent' &&
-                    accClass === 'Moderately Fluent' &&
-                    rateClass === 'Moderately Fluent') ||
-                  (exprClass === 'Very Disfluent' &&
-                    smoothClass === 'Moderately Fluent' &&
-                    accClass === 'Moderately Fluent' &&
-                    rateClass === 'Fluent')
-                ) {
-                  recordPass = true;
-                }
-              }
-            } else {
-              // For levels below M4, use the normal threshold.
-              recordPass = weightedScore >= passThreshold;
-            }
-
-            if (weightedScore >= passThreshold) {
-              passCount++;
-            }
-          }
-
-          // Even/odd logic:
-          // For even total audios: pass if passCount >= (totalAudios / 2)
-          // For odd total audios: pass if passCount > (totalAudios / 2)
-          if (totalAudios > 0) {
-            if (totalAudios % 2 === 0) {
-              fluencyResult = passCount >= totalAudios / 2 ? 'pass' : 'fail';
-            } else {
-              fluencyResult = passCount > totalAudios / 2 ? 'pass' : 'fail';
-            }
-          } else {
-            // If no audio records are present, assign a default value.
-            fluencyResult = 'fail';
-          }
-        }
-      }
-      let prosodyResult: string;
-      if (
-        !getSetResult.hasOwnProperty('collectionId') ||
-        !getSetResult.collectionId
-      ) {
-        if (showcaseLangs.includes(langLowerShowcase)) {
-          const userLevelNum = previous_level
-            ? parseInt(previous_level.replace('m', ''), 10)
-            : 0;
-          if (userLevelNum >= 6) {
-            const allAudioRecordsProsody =
-              await loadShowcaseSubSessionScores();
-
-            const totalAudiosProsody = allAudioRecordsProsody.length;
-            let passCountProsody = 0;
-
-            // Helper function: normalize classification – valid values are 'natural', 'flat', 'exaggerated', 'erratic'
-            const normalizeClassification = (cls: string): string => {
-              const valid = ['natural', 'flat', 'exaggerated', 'erratic'];
-              const lower = cls.toLowerCase();
-              return valid.includes(lower) ? lower : 'erratic';
-            };
-
-            for (const record of allAudioRecordsProsody) {
-              const prosody = record.prosody_fluency || {};
-              const pitchClass = normalizeClassification(
-                prosody.pitch?.pitch_classification || 'erratic',
-              );
-              const intensityClass = normalizeClassification(
-                prosody.intensity?.intensity_classification || 'erratic',
-              );
-              const tempoClass = normalizeClassification(
-                prosody.tempo?.tempo_classification || 'erratic',
-              );
-
-              // Rule 1: If any feature is 'erratic', record fails.
-              let recordProsodyPass = true;
-              if (
-                pitchClass === 'erratic' ||
-                intensityClass === 'erratic' ||
-                tempoClass === 'erratic'
-              ) {
-                recordProsodyPass = false;
-              } else {
-                // Rule 2: If 2 or more features are 'exaggerated', record fails.
-                let exaggeratedCount = 0;
-                if (pitchClass === 'exaggerated') exaggeratedCount++;
-                if (intensityClass === 'exaggerated') exaggeratedCount++;
-                if (tempoClass === 'exaggerated') exaggeratedCount++;
-                if (exaggeratedCount >= 2) {
-                  recordProsodyPass = false;
-                }
-              }
-              if (recordProsodyPass) {
-                passCountProsody++;
-              }
-            }
-
-            if (totalAudiosProsody > 0) {
-              prosodyResult =
-                totalAudiosProsody % 2 === 0
-                  ? passCountProsody >= totalAudiosProsody / 2
-                    ? 'pass'
-                    : 'fail'
-                  : passCountProsody > totalAudiosProsody / 2
-                    ? 'pass'
-                    : 'fail';
-            } else {
-              prosodyResult = 'fail';
-            }
-          } else {
-            // For users below level m6, we do not compute prosodyResult.
-            prosodyResult = undefined;
-          }
-        }
-      }
+      const { fluencyResult, prosodyResult } = await this.scoresService.computeFluencyAndProsodyResults(
+        user_id,
+        subSessionId,
+        requestLanguage,
+        getSetResult.collectionId,
+        previous_level,
+      );
 
       // If fluencyResult is computed and is 'fail', enforce overall sessionResult to 'fail'
       // But don't override ansSelectionStatus results for char content type
       if (
         !hasAnsSelectionStatus && // Only apply fluency override if we don't have ansSelectionStatus
-        ((typeof fluencyResult !== 'undefined' && fluencyResult === 'fail') ||
-          (typeof prosodyResult !== 'undefined' && prosodyResult === 'fail'))
+        ((typeof fluencyResult !== 'undefined' && fluencyResult === SessionResult.FAIL) ||
+          (typeof prosodyResult !== 'undefined' && prosodyResult === SessionResult.FAIL))
       ) {
         sessionResult = 'fail';
       }
@@ -6493,17 +6306,6 @@ export class ScoresController {
       }
 
       let currentLevel = milestone_level;
-
-      if (
-        !(
-          (['en', 'kn', 'te', 'hi', 'ta', 'or', 'gu'].includes(getSetResult.language.toLowerCase())) &&
-          (!getSetResult.hasOwnProperty('collectionId') ||
-            !getSetResult.collectionId)
-        )
-      ) {
-        fluencyResult = undefined;
-        prosodyResult = undefined;
-      }
 
       if (milestoneEntry) {
         let sub_milestone_level = '';

--- a/src/mongodb/scores.controller.ts
+++ b/src/mongodb/scores.controller.ts
@@ -6157,8 +6157,8 @@ export class ScoresController {
       // But don't override ansSelectionStatus results for char content type
       if (
         !hasAnsSelectionStatus && // Only apply fluency override if we don't have ansSelectionStatus
-        ((typeof fluencyResult !== 'undefined' && fluencyResult === SessionResult.FAIL) ||
-          (typeof prosodyResult !== 'undefined' && prosodyResult === SessionResult.FAIL))
+        ((fluencyResult !== undefined && fluencyResult === SessionResult.FAIL) ||
+          (prosodyResult !== undefined && prosodyResult === SessionResult.FAIL))
       ) {
         sessionResult = 'fail';
       }

--- a/src/mongodb/scores.service.ts
+++ b/src/mongodb/scores.service.ts
@@ -27,6 +27,12 @@ import {
   ErrorCodes,
   mapAxiosToUpstreamHttpException,
 } from 'src/common/exceptions/api.exceptions';
+import {
+  FluencyClassification,
+  ProsodyClassification,
+  SessionResult,
+  SUPPORTED_LANGUAGES,
+} from 'src/common/enums/scores.enum';
 
 @Injectable()
 export class ScoresService {
@@ -3083,14 +3089,13 @@ export class ScoresService {
 
   public classificationToScore(classification: string): number {
     switch (classification) {
-      case 'Fluent':
+      case FluencyClassification.FLUENT:
         return 4;
-      case 'Moderately Fluent':
+      case FluencyClassification.MODERATELY_FLUENT:
         return 3;
-      case 'Disfluent':
+      case FluencyClassification.DISFLUENT:
         return 2;
-      case 'Very Disfluent':
-        return 1;
+      case FluencyClassification.VERY_DISFLUENT:
       default:
         return 1;
     }
@@ -3126,6 +3131,117 @@ export class ScoresService {
       return acc;
     }, []);
     return sessions;
+  }
+
+  async computeFluencyAndProsodyResults(
+    userId: string,
+    subSessionId: string,
+    language: string,
+    collectionId: string | undefined,
+    previousLevel: string | undefined,
+  ): Promise<{ fluencyResult: SessionResult | undefined; prosodyResult: SessionResult | undefined }> {
+    const langLower = language.toLowerCase();
+
+    if (collectionId || !SUPPORTED_LANGUAGES.includes(langLower)) {
+      return { fluencyResult: undefined, prosodyResult: undefined };
+    }
+
+    const userLevelNum = previousLevel ? parseInt(previousLevel.replace('m', ''), 10) : NaN;
+    const needsFluency = !isNaN(userLevelNum) && userLevelNum < 10;
+    const needsProsody = !isNaN(userLevelNum) && userLevelNum >= 6;
+
+    if (!needsFluency && !needsProsody) {
+      return { fluencyResult: undefined, prosodyResult: undefined };
+    }
+
+    // Single DB call shared between both computations.
+    const audioRecords = await this.getSubSessionScores(userId, subSessionId, langLower);
+    const total = audioRecords.length;
+
+    const { passThresholdM4Plus, passThresholdBelowM4, weights } =
+      lang_common_config.fluencyAndProsody;
+
+    let fluencyResult: SessionResult | undefined;
+    if (needsFluency) {
+      const passThreshold = userLevelNum >= 4 ? passThresholdM4Plus : passThresholdBelowM4;
+      let passCount = 0;
+
+      for (const record of audioRecords) {
+        const prosody = record.prosody_fluency || {};
+        const exprClass: string = prosody.expression_classification || FluencyClassification.VERY_DISFLUENT;
+        const smoothClass: string = prosody.smoothness?.smoothness_classification || FluencyClassification.VERY_DISFLUENT;
+        const accClass: string = prosody.accuracy?.accuracy_classification || FluencyClassification.VERY_DISFLUENT;
+        const rateClass: string = prosody.rate?.rate_classification || FluencyClassification.VERY_DISFLUENT;
+
+        const weightedScore =
+          this.classificationToScore(exprClass) * weights.expression +
+          this.classificationToScore(smoothClass) * weights.smoothness +
+          this.classificationToScore(accClass) * weights.accuracy +
+          this.classificationToScore(rateClass) * weights.rate;
+
+        let recordPass: boolean;
+        if (userLevelNum >= 4) {
+          if (weightedScore >= passThreshold) {
+            recordPass = true;
+          } else {
+            // Exception: three borderline combinations score 2.9 but are intentionally passing.
+            recordPass =
+              (exprClass === FluencyClassification.MODERATELY_FLUENT && smoothClass === FluencyClassification.DISFLUENT && accClass === FluencyClassification.MODERATELY_FLUENT && rateClass === FluencyClassification.MODERATELY_FLUENT) ||
+              (exprClass === FluencyClassification.DISFLUENT && smoothClass === FluencyClassification.FLUENT && accClass === FluencyClassification.MODERATELY_FLUENT && rateClass === FluencyClassification.MODERATELY_FLUENT) ||
+              (exprClass === FluencyClassification.VERY_DISFLUENT && smoothClass === FluencyClassification.MODERATELY_FLUENT && accClass === FluencyClassification.MODERATELY_FLUENT && rateClass === FluencyClassification.FLUENT);
+          }
+        } else {
+          recordPass = weightedScore >= passThreshold;
+        }
+
+        if (recordPass) {
+          passCount++;
+        }
+      }
+
+      fluencyResult = total === 0
+        ? SessionResult.FAIL
+        : total % 2 === 0
+          ? passCount >= total / 2 ? SessionResult.PASS : SessionResult.FAIL
+          : passCount > total / 2 ? SessionResult.PASS : SessionResult.FAIL;
+    }
+
+    let prosodyResult: SessionResult | undefined;
+    if (needsProsody) {
+      const validProsodyClasses: string[] = Object.values(ProsodyClassification);
+      const normalizeClass = (cls: string): string => {
+        const lower = cls.toLowerCase();
+        return validProsodyClasses.includes(lower) ? lower : ProsodyClassification.ERRATIC;
+      };
+
+      let passCountProsody = 0;
+
+      for (const record of audioRecords) {
+        const prosody = record.prosody_fluency || {};
+        const pitchClass = normalizeClass(prosody.pitch?.pitch_classification || ProsodyClassification.ERRATIC);
+        const intensityClass = normalizeClass(prosody.intensity?.intensity_classification || ProsodyClassification.ERRATIC);
+        const tempoClass = normalizeClass(prosody.tempo?.tempo_classification || ProsodyClassification.ERRATIC);
+
+        const exaggeratedCount = [pitchClass, intensityClass, tempoClass].filter(
+          (c) => c === ProsodyClassification.EXAGGERATED,
+        ).length;
+        const recordProsodyPass =
+          pitchClass !== ProsodyClassification.ERRATIC &&
+          intensityClass !== ProsodyClassification.ERRATIC &&
+          tempoClass !== ProsodyClassification.ERRATIC &&
+          exaggeratedCount < 2;
+
+        if (recordProsodyPass) passCountProsody++;
+      }
+
+      prosodyResult = total === 0
+        ? SessionResult.FAIL
+        : total % 2 === 0
+          ? passCountProsody >= total / 2 ? SessionResult.PASS : SessionResult.FAIL
+          : passCountProsody > total / 2 ? SessionResult.PASS : SessionResult.FAIL;
+    }
+
+    return { fluencyResult, prosodyResult };
   }
 
   public async getComprehensionScore(

--- a/src/mongodb/scores.service.ts
+++ b/src/mongodb/scores.service.ts
@@ -3049,42 +3049,38 @@ export class ScoresService {
     return outcomes.size > 0 ? Array.from(outcomes) : [word];
   }
 
-  getAccuracyClassification(contentType: string, score: number): string {
-    const config: Record<string, [number, number, string][]> = {
+  getAccuracyClassification(contentType: string, score: number): FluencyClassification | 'N/A' {
+    const config: Record<string, [number, number, FluencyClassification][]> = {
       word: [
-        [0, 1, "Fluent"],
-        [1, 2, "Moderately Fluent"],
-        [2, 3, "Disfluent"],
-        [3, Infinity, "Very Disfluent"]
+        [0, 1, FluencyClassification.FLUENT],
+        [1, 2, FluencyClassification.MODERATELY_FLUENT],
+        [2, 3, FluencyClassification.DISFLUENT],
+        [3, Infinity, FluencyClassification.VERY_DISFLUENT],
       ],
       sentence: [
-        [0, 3, "Fluent"],
-        [3, 6, "Moderately Fluent"],
-        [6, 8, "Disfluent"],
-        [8, Infinity, "Very Disfluent"]
+        [0, 3, FluencyClassification.FLUENT],
+        [3, 6, FluencyClassification.MODERATELY_FLUENT],
+        [6, 8, FluencyClassification.DISFLUENT],
+        [8, Infinity, FluencyClassification.VERY_DISFLUENT],
       ],
       paragraph: [
-        [0, 5, "Fluent"],
-        [5, 10, "Moderately Fluent"],
-        [10, 12, "Disfluent"],
-        [12, Infinity, "Very Disfluent"]
-      ]
+        [0, 5, FluencyClassification.FLUENT],
+        [5, 10, FluencyClassification.MODERATELY_FLUENT],
+        [10, 12, FluencyClassification.DISFLUENT],
+        [12, Infinity, FluencyClassification.VERY_DISFLUENT],
+      ],
     };
-    // Normalize the content type and get its thresholds.
     const ct = contentType.toLowerCase();
     const thresholds = config[ct];
-    // If the content type is not recognized, return "N/A"
     if (!thresholds) {
-      return "N/A";
+      return 'N/A';
     }
-    // Loop through the thresholds and return the classification that matches.
     for (const [min, max, label] of thresholds) {
       if (score >= min && score <= max) {
         return label;
       }
     }
-    // Fallback in case no classification is matched.
-    return "N/A";
+    return 'N/A';
   }
 
   public classificationToScore(classification: string): number {


### PR DESCRIPTION
…ordPass bug, add enums and config

- Move fluencyResult and prosodyResult computation out of getSetResult controller into new ScoresService.computeFluencyAndProsodyResults method
- Fix dead-code bug where M4+ exception combinations (score 2.9) never counted as passes due to passCount++ using raw weightedScore instead of recordPass flag
- Add src/common/enums/scores.enum.ts with FluencyClassification, ProsodyClassification, SessionResult, SupportedLanguage enums
- Add fluencyAndProsody config (thresholds and weights) to commonConfig.ts
- Remove redundant fluencyResult/prosodyResult reset block from controller
- Single DB call now shared between fluency and prosody computations